### PR TITLE
Added feature to continuously check the time and update the daily planner

### DIFF
--- a/Assets/js/script.js
+++ b/Assets/js/script.js
@@ -1,29 +1,25 @@
-/* Obtains all the event information from the localStorage and displays it in their corresponding sections on the 
-page */
-$(window).on('load',function() {
+var saveBtn = $(".saveBtn");
+
+/* Obtains all the event information from the localStorage and displays it in their corresponding sections on the page */
+$(window).on("load", function () {
   var saved_events = JSON.parse(localStorage.getItem("saved_events"));
   if (saved_events == null) {
     saved_events = {};
   }
 
   for (const event in saved_events) {
-    const eventTimeEl = $(`#${event}`); //Element containing the id representing the event time in the local storage
+    const eventTimeEl = $(`#${event}`); //Element containing the id representing the event time stored in the local storage
     const eventText = saved_events[event];
     eventTimeEl.children("textarea, .description").text(eventText); //Traverses through the DOM to edit the description of the textarea corresponding to the event time
   }
+});
 
-  displayDay();
-  checkTime();
-})
-
-var saveBtn = $(".saveBtn");
 
 /* Obtains the time and description of the event when it is saved by the user and saves it to the local storage*/
-saveBtn.on('click', function () {
-  var btnclicked = $(this) //JQuery object of the DOM element that was clicked on (the save button)
+saveBtn.on("click", function () {
+  var btnclicked = $(this); //JQuery object of the DOM element that was clicked on (the save button)
 
-  //Traverses through the DOM to obtain the event time (id of the parent element) and 
-  //description(value of the textarea sibling element)
+  //Traverses through the DOM to obtain the event's time (id of the parent element) and description(value of the textarea sibling element)
   var eventTime = btnclicked.parents(".time-block")[0].id;
   var eventText = btnclicked.siblings("textarea, .description").val();
 
@@ -33,27 +29,31 @@ saveBtn.on('click', function () {
   }
   saved_events[eventTime] = eventText;
   localStorage.setItem("saved_events", JSON.stringify(saved_events));
-})
+});
 
-var today = dayjs(); //Get's today's date
+//Continuously checks the time every second and displays it
+var updateTime = setInterval(() => {
+  var today = dayjs(); //Get's today's date
+  displayTime(today);
+  checkTime(today);
+}, 1000);
+
 
 //Displays the current day on the screen
-function displayDay() {
-  var currentDay = today.format("dddd, MMMM D"); //Get the formatted date according to the string of tokens passed in.
+function displayTime(today) {
+  var currentDay = today.format("dddd, MMMM D - hh:mm a"); //Get the formatted date according to the string of tokens passed in.
   $("#currentDay").text(currentDay); //Displays the formatted date on the screen
 }
 
-/* Checks the current hour of the day and compares it to the work hours in the day planner.
-One of three classes (past,present,and future) is applied to the div sections of each work hour based on 
-it's relation the current hour. These classes apply color stylings to help visually display the hours of the work
-day. */
-function checkTime() {
 
+/* Checks the current hour of the day and compares it to the work hour div's in the day planner. One of three classes (past,present,and future) 
+is applied to the div sections of each work hour based on it's relation the current hour.*/
+function checkTime(today) {
   var currentHour = today.hour(); //Get's the current hour
-  var workHours = $(".time-block"); //Get's an array of all time block div's in HTML 
+  var workHours = $(".time-block"); //Get's an array of all time block div's in HTML
 
   for (var hour = 0; hour < workHours.length; hour++) {
-    elementHour = parseInt(workHours[hour].id.split("-")[1]); //Obtains the corresponding hour (24-hr time) of a div element using its id 
+    elementHour = parseInt(workHours[hour].id.split("-")[1]); //Obtains the corresponding hour (24-hr time) of a div element using its id
     if (elementHour < currentHour) {
       $(workHours[hour]).removeClass("present");
       $(workHours[hour]).removeClass("future");
@@ -69,6 +69,11 @@ function checkTime() {
     }
   }
 }
+
+
+
+
+
 
 
 // Wrap all code that interacts with the DOM in a call to jQuery to ensure that


### PR DESCRIPTION
- Changed name of function from displayDay to displayTime
- displayTime prints the date as well as the current time in [hh:mm a] format where hh is the 2-digit hour in a 12 hour clock, mm is the minimute in 2 digits, and a represents if the time is am or pm

- Set an interval function that runs every second
- The interval runs day.js to continuously get the current time
- The interval calls the displayTime and checkTime function to continuously print the current time on the page, as well as compare the current time with the time represented in the div elements
- This interval will allow the page to continuously update without having to refresh the page